### PR TITLE
Some major cleanup

### DIFF
--- a/generate_structure.sh
+++ b/generate_structure.sh
@@ -3,7 +3,7 @@
 # This file generates directories and other files 
 # for the convenience of developers and students.
 
-echo "GENERATING FILE CABINET"
+printf "GENERATING FILE CABINET"
 
 mkdir Desktop
 
@@ -29,7 +29,7 @@ mkdir -p Pictures/{gif,jpeg,png/screenshot,svg,wallpapers,xcf}
 
 # TEMPLATES
 mkdir -p Templates/{CONFIGURATION,DOCUMENTS/{LIBRE,OTHER},PROGRAMMING/{A,C,D,F,G,H,J,O,P,R,S},SCRIPTING/{L,P,SHELL},WEB}
-echo "WRITING TEMPLATES"
+printf "WRITING TEMPLATES"
 
 printf "GENERATING ADA TEMPLATE\n"
 printf "Text_IO;\n\n\

--- a/generate_structure.sh
+++ b/generate_structure.sh
@@ -4,33 +4,52 @@
 # This file generates directories and other files 
 # for the convenience of developers and students.
 
-printf "GENERATING FILE CABINET"
+echo "GENERATING FILE CABINET"
 
-mkdir Desktop
+if [ ! -d Desktop ]; then
+	mkdir Desktop
+fi
 
 # DOCUMENTS
 # Create the Documents directory along with the subdirectories.
-mkdir -p Documents/office/{calc,draw,impress,math,writer}
+if [ ! -d Documents ]; then
+	mkdir -p Documents/office/{calc,draw,impress,math,writer}
+fi
 # Create the programming directory along with the subdirectories.
-mkdir -p programming/{assembly,c,cpp,d,forth,go,haskell,ruby,rust}
+if [ ! -d programming ]; then
+	mkdir -p programming/{assembly,c,cpp,d,forth,go,haskell,ruby,rust}
+fi
 # Create the scripting directory along with the subdirectories.
-mkdir -p scripting/{lua,python,shell/{bash,dash,fish,zsh}}
+if [ ! -d scripting ]; then
+	mkdir -p scripting/{lua,python,shell/{bash,dash,fish,zsh}}
+fi
 # Create the web directory along with the subdirectories.
+if [ ! -d web ]; then
 mkdir -p web/html/{css,html,javascript,media/{audio/{flac,mp3,ogg},photo/{gif,jpeg,png,svg},video/{mp4,ogv,webm}},php}
+fi
 
 # DOWNLOADS
-mkdir -p Downloads/{7zip,iso,other,tarball,zip}
+if [ ! -d Downloads ]; then
+	mkdir -p Downloads/{7zip,iso,other,tarball,zip}
+fi
 
 # MUSIC
 # You will need to create directories for each band or artist yourself. We don't know who you listen to or what file format you may download as.  
-mkdir -p Music/{aup,flac,mp3,ogg}
+if [ ! -d Music ]; then
+	mkdir -p Music/{aup,flac,mp3,ogg}
+fi
 
 # PICTURES
-mkdir -p Pictures/{gif,jpeg,png/screenshot,svg,wallpapers,xcf}
+if [ ! -d Pictures ]; then
+	mkdir -p Pictures/{gif,jpeg,png/screenshot,svg,wallpapers,xcf}
+fi
 
 # TEMPLATES
-mkdir -p Templates/{CONFIGURATION,DOCUMENTS/{LIBRE,OTHER},PROGRAMMING/{A,C,D,F,G,H,J,O,P,R,S},SCRIPTING/{L,P,SHELL},WEB}
-printf "WRITING TEMPLATES"
+if [ ! -d Templates ]; then
+	mkdir -p Templates/{CONFIGURATION,DOCUMENTS/{LIBRE,OTHER},PROGRAMMING/{A,C,D,F,G,H,J,O,P,R,S},SCRIPTING/{L,P,SHELL},WEB}
+fi
+
+printf "WRITING TEMPLATES\n"
 
 printf "GENERATING ADA TEMPLATE\n"
 printf "Text_IO;\n\n\

--- a/generate_structure.sh
+++ b/generate_structure.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # SETUP
 # AUTHOR: Dalton "Joey" Hill
 # This file generates directories and other files 

--- a/generate_structure.sh
+++ b/generate_structure.sh
@@ -1,379 +1,215 @@
 # SETUP
 # AUTHOR: Dalton "Joey" Hill
 # This file generates directories and other files 
-# for the  convenience of developers and students.
-
-# NOTE; We're using multiple CD commands for easy tracking. 
+# for the convenience of developers and students.
 
 echo "GENERATING FILE CABINET"
 
 mkdir Desktop
 
 # DOCUMENTS
-mkdir Documents
-cd Documents
-	mkdir office
-	cd office
-		mkdir calc draw impress math writer
-	cd ..
-	mkdir programming
-	cd programming
-		mkdir assembly c cpp d forth go haskell ruby rust
-	cd ..
-	mkdir scripting
-	cd scripting
-		mkdir lua python shell
-		cd shell
-			mkdir bash dash fish zsh
-		cd ..
-	cd ..
-	mkdir web
-	cd web
-		mkdir html
-		cd html
-			mkdir css html javascript media php
-			cd media
-				mkdir audio photo video
-				cd audio
-					mkdir flac mp3 ogg
-				cd ..
-				cd photo
-					mkdir gif jpeg png svg
-				cd ..
-				cd video
-					mkdir mp4 ogv webm
-				cd ..
-			cd ..
-		cd ..
-	cd ..
-cd ..
+# Create the Documents directory along with the subdirectories.
+mkdir -p Documents/office/{calc,draw,impress,math,writer}
+# Create the programming directory along with the subdirectories.
+mkdir -p programming/{assembly,c,cpp,d,forth,go,haskell,ruby,rust}
+# Create the scripting directory along with the subdirectories.
+mkdir -p scripting/{lua,python,shell/{bash,dash,fish,zsh}}
+# Create the web directory along with the subdirectories.
+mkdir -p web/html/{css,html,javascript,media/{audio/{flac,mp3,ogg},photo/{gif,jpeg,png,svg},video/{mp4,ogv,webm}},php}
 
 # DOWNLOADS
-mkdir Downloads
-cd Downloads
-	mkdir 7zip iso other tarball zip
-cd ..
+mkdir -p Downloads/{7zip,iso,other,tarball,zip}
 
 # MUSIC
-mkdir Music
-cd Music
-	mkdir aup flac mp3 ogg
-	# You will need to create directories for each band or artist yourself. We don't know who you listen to or what file format you may download as.  
-cd ..
+# You will need to create directories for each band or artist yourself. We don't know who you listen to or what file format you may download as.  
+mkdir -p Music/{aup,flac,mp3,ogg}
 
-mkdir Pictures
-cd Pictures
-	mkdir gif jpeg png svg wallpapers xcf
-		cd png
-			mkdir screenshot
-		cd ..
-cd ..
+# PICTURES
+mkdir -p Pictures/{gif,jpeg,png/screenshot,svg,wallpapers,xcf}
 
 # TEMPLATES
-mkdir Templates
-cd Templates
-	# PROGRAMMNG DIRECTORY
-	echo "WRITING TEMPLATES"
+mkdir -p Templates/{CONFIGURATION,DOCUMENTS/{LIBRE,OTHER},PROGRAMMING/{A,C,D,F,G,H,J,O,P,R,S},SCRIPTING/{L,P,SHELL},WEB}
+echo "WRITING TEMPLATES"
 
-	mkdir PROGRAMMING
-	cd PROGRAMMING
-		mkdir A
-		cd A
-		touch ada.adb apl.apl assembly-n.asm
-			echo "GENERATING ADA TEMPLATE"
-			echo 'with Ada.Text_IO;' 				>> ada.adb
-			echo '' 						>> ada.adb
-			echo 'procedure Hello_World is' 			>> ada.adb
-			echo 'begin' 						>> ada.adb
-			echo '	Ada.Text_IO.Put_Line ("Hello, World!");' 	>> ada.adb
-			echo 'end Hello_World;' 				>> ada.adb
+printf "GENERATING ADA TEMPLATE\n"
+printf "Text_IO;\n\n\
+	procedure Hello_World is\n\
+	begin\n\
+		Ada.Text_IO.Put_Line ('Hello, World!');\n\
+	end Hello_World;\n" > Templates/PROGRAMMING/A/ada.adb
 
-			echo "GENERATING APL TEMPLATE" 				>> apl.apl
-			echo "[]<-'Hello World!'" 				>> apl.apl
+printf "GENERATING APL TEMPLATE\n"
+printf "[]<-'Hello World!'\n" > Templates/PROGRAMMING/A/apl.apl
 
-			echo "GENERATING ASSEMBLY TEMPLATE FOR NASM"
-			echo 'global _start' 					>> assembly-n.asm
-			echo '' 						>> assembly-n.asm
-			echo 'section .text' 					>> assembly-n.asm
-			echo '_start:' 						>> assembly-n.asm
-			echo '	mov rax, 1	; write(' 			>> assembly-n.asm
-			echo '	mov rdi, 1	;   STDOUT_FILENO,' 		>> assembly-n.asm
-			echo '	mov rsi, msg	;   "Hello, World!\n",' 	>> assembly-n.asm
-			echo '	mov rdx, msglen	;   sizeof("Hello, World!\n")' 	>> assembly-n.asm
-			echo '	syscall		; );' 				>> assembly-n.asm
-			echo '' 						>> assembly-n.asm
-			echo '	mov rax, 60	; exit(' 			>> assembly-n.asm
-			echo '	mov rdi, 0	;   EXIT_SUCCESS' 		>> assembly-n.asm
-			echo '	syscall		; );' 				>> assembly-n.asm
-			echo '' 						>> assembly-n.asm
-			echo '	syscall		; );' 				>> assembly-n.asm
-			echo 'section .rodata' 					>> assembly-n.asm
-			echo '	msg: db "Hello, World!", 10' 			>> assembly-n.asm
-			echo '	msglen: equ $ - msg' 				>> assembly-n.asm
+printf "GENERATING ASSEMBLY TEMPLATE FOR NASM\n"
+printf "global _start\n\n\
+	section .text
+	_start:
+		mov rax, 1	; write(\n\
+		mov rdi, 1	;   STDOUT_FILENO,\n\
+		mov rsi, msg	;   'Hello, World!\n',\n\
+		mov rdx, msglen	;   sizeof('Hello, World!\n')\n\
+		syscall		; );\n\n\
+		mov rax, 60	; exit(\n\
+		mov rdi, 0	;   EXIT_SUCCESS\n\
+		syscall		; );\n\n\
+		syscall		; );\n\
+	section .rodata\n\
+		msg: db 'Hello, World!', 10\n\
+		msglen: equ $ - msg" > Templates/PROGRAMMING/A/assembly-n.asm
 
-		cd ..
+printf "GENERATING C TEMPLATE\n"
+printf "#include <stdio.h>\n\n\
+	int main() {\n\
+		printf(\"Hello World!\");\n\
+		return 0;\n\
+	}" > Templates/PROGRAMMING/C/c.c
 
-		mkdir C
-		cd C
-		touch c.c c.h cobol.cbl cobol.cob cobol.cpy cpp.cpp cpp.hpp csharp.cs
-			echo "GENERATING C TEMPLATE"
-			echo '#include <stdio.h>' 				>> c.c
-			echo '' 						>> c.c
-			echo 'int main() {' 					>> c.c
-			echo '	printf("Hello World!");' 			>> c.c
-			echo '	return 0;' 					>> c.c
-			echo '}' 						>> c.c
+printf "GENERATING C++ FILE\n"
+printf "#include <iostream>\n\n\
+	int main() {\n\
+		std::cout << \"Hello, World!\" << std::endl;\n\
+		return 0;\n\
+	}" > Templates/PROGRAMMING/C/cpp.cpp
 
-			echo "GENERATING C++ FILE"
-			echo '#include <iostream>' 				>> cpp.cpp
-			echo 'using namespace std;' 				>> cpp.cpp
-			echo 'int main() {' 					>> cpp.cpp
-			echo '	cout << "Hello, World!" << endl;' 		>> cpp.cpp
-			echo '	return 0;' 					>> cpp.cpp
-			echo '}' 						>> cpp.cpp
+printf "GENERATING COBOL TEMPLATE\n"
+printf "IDENTIFICATION DIVISION.\n\
+	PROGRAM-ID. IDSAMPLE.\n\
+	ENVIRONMENT DIVISION.\n\
+	PROCEDURE DIVISION.\n\
+		DISPLAY \"HELLO WORLD\".\n\
+		STOP RUN." > Templates/PROGRAMMING/C/cobol.cbl
 
-			echo "GENERATING COBOL TEMPLATE"
-			echo 'IDENTIFICATION DIVISION.' 			>> cobol.cbl
-			echo 'PROGRAM-ID. IDSAMPLE.' 				>> cobol.cbl
-			echo 'ENVIRONMENT DIVISION.' 				>> cobol.cbl
-			echo 'PROCEDURE DIVISION.' 				>> cobol.cbl
-			echo "	DISPLAY 'HELLO WORLD'." 			>> cobol.cbl
-			echo '	STOP RUN.' 					>> cobol.cbl
+printf "GENERATING D TEMPLATE\n"
+printf "import std.stdio;\n\n\
+	void main() {\n\
+		writefln(\"Hello, World!\");\n\
+	}" > Templates/PROGRAMMING/D/d.d
+
+printf "GENERATING FORTH TEMPLATE\m"
+printf " : HELLO  ( -- )  CR .\" Hello, World!\" ;\n" > Templates/PROGRAMMING/F/forth.fth
+
+printf "GENERATING F# TEMPLATE\n"
+printf "[<EntryPoint>]\n\
+	let main argv =\n\
+		printfn \"Hello, World!\"\n\
+		0" > Templates/PROGRAMMING/F/fsharp.fs
+
+printf "GENERATING GO TEMPLATE\n"
+printf "package main\n\n\
+	import 'fmt'\n\n\
+	func main() {\n\
+		fmt.Println(\"Hello, World!\")\n\
+	}" > Templates/PROGRAMMING/G/golang.go
+
+printf "GENERATING HASKELL TEMPLATE\n"
+printf "main :: IO ()\n\
+	main = putStrLn \"Hello, World!\"" > Templates/PROGRAMMING/H/haskell.hs
+
+printf "GENERATING JAVA TEMPLATE\n"
+printf "class HelloWorld {\n\
+		public static void main(String[] args) {\n\
+			System.out.println(\"Hello, World!\");\n\
+		}\n\
+	}" > Templates/PROGRAMMING/J/java.jar
+
+printf "GENERATING OCAML TEMPLATE\n"
+printf "print_string \"Hello World\n\"" > Templates/PROGRAMMING/O/oca.ml
+
+printf "GENERATING PROLOG TEMPLATE\n"
+printf "write(\"Hello, World!\")." > Templates/PROGRAMMING/P/prolog.pro
+
+printf "GENERATING R TEMPLATE\n"
+printf "print(\"Hello World!\", quote=FALSE)" > Templates/PROGRAMMING/R/r.r
+
+printf "GENERATING RUBY TEMPLATE\n"
+printf "puts \"Hello, World!\"" > Templates/PROGRAMMING/R/ruby.rb
+
+printf "GENERATING RUST TEMPLATE\n"
+printf "fn main() {\n\
+		println!(\"Hello, World!\");\n\
+	}" > Templates/PROGRAMMING/R/rust.rs
+
+printf "GENERATING SWIFT TEMPLATE\n"
+printf "print(\"Hello, World!\")" > Templates/PROGRAMMING/S/swift.swift
 
 
-
-		cd ..
-
-		mkdir D
-		cd D
-		touch d.d
-			echo "GENERATING D TEMPLATE"
-			echo 'import std.stdio;' 				>> d.d
-			echo '' 						>> d.d
-			echo 'void main()' 					>> d.d
-			echo '{' 						>> d.d
-			echo '	writefln("Hello, World!");' 			>> d.d
-			echo '}' 						>> d.d
-		cd ..
-
-		mkdir F
-		cd F
-		touch f.f forth.fth fsharp.fs
-
-			echo "GENERATING FORTH TEMPLATE"
-			echo ' : HELLO  ( -- )  CR ." Hello, World!" ;' 	>> forth.fth
-
-			echo "GENERATING F# TEMPLATE"
-			echo '[<EntryPoint>]' 					>> fsharp.fs
-			echo 'let main argv =' 					>> fsharp.fs
-			echo '	printfn "Hello, World!"' 			>> fsharp.fs
-			echo '	0' 						>> fsharp.fs
+# CONFIGURATION DIRECTORY
+printf "GENERATING EMPTY CONFIGURATION FILES\n"
+touch Templates/CONFIGURATION/{configure.config,json.json,toml.toml,yaml.yaml}
 
 
-		cd ..
+# DOCUMENTS
+printf "GENERATING LIBRE OFFICE FILES\n"
+touch Templates/DOCUMENTS/LIBRE/{calc.ods,draw.odg,impress.odp,math.odf,writer.odt}
 
-		mkdir G
-		cd G
-		touch golang.go
-			echo "GENERATING GO TEMPLATE"
-			echo 'package main' 					>> golang.go
-			echo '' 						>> golang.go
-			echo 'import "fmt"' 					>> golang.go
-			echo '' 						>> golang.go
-			echo 'func main() {' 					>> golang.go
-			echo '	fmt.Println("Hello, World!")' 			>> golang.go
-			echo '}' 						>> golang.go
-		cd ..
+printf "GENERATING DESKTOP FILE\n"
+printf "[Desktop Entry]\n\
+	Version=1.0\n\
+	Type=Application\n\
+	Name=labelyourapp\n\
+	Comment=shortdescriptionhere\n\
+	Exec=appnamehere\n\
+	Icon=/path/to/file\n\
+	Path=\n\
+	Terminal=true/false\n\
+	StartupNotify=true/false" > Templates/DOCUMENTS/OTHER/desktop.desktop
 
-		mkdir H
-		cd H
-		touch haskell.hs
-			echo "GENERATING HASKELL TEMPLATE"
-			echo 'main :: IO ()' 					>> haskell.hs
-			echo 'main = putStrLn "Hello, World!"' 			>> haskell.hs
-		cd ..
+printf "GENERATING LUA TEMPLATE\n"
+printf "print('Hello, World!')" > Templates/SCRIPTING/L/lua.lua
 
-		mkdir J
-		cd J
-		touch java.class java.j java.jar java.jav java.java jsharp.jsl
-			echo "GENERATING JAVA TEMPLATE"
-			echo 'class HelloWorld {' 				>> java.jar
-			echo '	public static void main(String[] args) {' 	>> java.jar
-			echo '		System.out.println("Hello, World!");' 	>> java.jar
-			echo '	}' 						>> java.jar
-			echo '}' 						>> java.jar
-		cd ..
+printf "GENERATING PYTHON TEMPLATE\n"
+printf "#!/usr/bin/env python\n\
+	print \"Hello, World\"" > Templates/SCRIPTING/P/python.py
 
-		mkdir O
-		cd O
-		touch objective_c.m objective_c.M objective_c.mm oca.ml ocaml.mli
-			echo "GENERATING OCAML TEMPLATE"
-			echo 'print_string "Hello World\n"' 			>> oca.ml
-		cd ..
+printf "GENERATING VARIOUS SHELL SCRIPT TEMPLATES\n"
 
-		mkdir P
-		cd P
-		touch p.p prolog.pro
-			echo "GENERATING PROLOG TEMPLATE"
-			echo "write('Hello, World!')." 				>> prolog.pro
-		cd ..
+printf "#!/bin/bash\n\
+	printf 'Hello, World!\n'" > Templates/SCRIPTING/SHELL/bash.sh
 
-		mkdir R
-		cd R
-		touch r.r ruby.rb rust.rs
-			echo 'print("Hello World!", quote=FALSE)' >> r.r
+printf "#!/bin/dash\n\
+	echo 'Hello, World!'" > Templates/SCRIPTING/SHELL/dash.sh
 
-			echo "GENERATING RUBY TEMPLATE"
-			echo 'puts "Hello, World!"' 				>> ruby.rb
+printf "#!/bin/fish\n\
+	echo 'Hello, World!'" > Templates/SCRIPTING/SHELL/fish.sh
 
-			echo "GENERATING RUST TEMPLATE"
-			echo 'fn main() {' 					>> rust.rs 
-			echo '	println!("Hello, World!");' 			>> rust.rs 
-			echo '}' 						>> rust.rs
-		cd ..
+printf "#!/bin/ion\n\
+	echo 'Hello, World!'" > Templates/SCRIPTING/SHELL/ion.sh
 
-		mkdir S
-		cd S
-		touch swift.swift swift.SWIFT
-			echo "GENERATING SWIFT TEMPLATE"
-			echo 'print("Hello, World!")' 				>> swift.swift
-		cd ..
+printf "#!/bin/nu\n\
+	echo 'Hello, World!'" > Templates/SCRIPTING/SHELL/nu.sh
 
-	cd .. 
+printf "#!/bin/zsh\n\
+	echo 'Hello, World!'" > Templates/SCRIPTING/SHELL/z.sh
 
-	# CONFIGURATION DIRECTORY
+# WEB
+printf "GENERATING EMPTY CSS FILE\n"
+printf ".class {\n\n\
+        }\n\n\
+	#id {\n\n\
+	}" > Templates/WEB/css.css
 
-	mkdir CONFIGURATION
-	cd CONFIGURATION
-		echo "GENERATING EMPTY CONFIGURATION FILES"
-		touch configure.config json.json toml.toml yaml.yaml 
+printf "GENERATING HTML TEMPLATE\n"
+printf "<html>\n\
+	  <head>\n\
+	  </head>\n\n\
+	  <body>\n\
+	    <script src='Documents/web/html'>\n\
+	    </script>\n\
+	    <p>\n\
+	    </p>\n\
+	  </body>\n\
+	</html>" > Templates/WEB/html.html
 
-	cd ..
+printf "GENERATING JAVASCRIPT TEMPLATE\n"
+printf "alert(\"Hello, world! I am a separate file.\");" > Templates/WEB/javascript.js
 
-	# DOCUMENTS
-
-	mkdir DOCUMENTS
-	cd DOCUMENTS
-
-		mkdir LIBRE
-		cd LIBRE
-			echo "GENERATING LIBRE OFFICE FILES"
-			touch calc.ods draw.odg impress.odp math.odf writer.odt
-		cd ..
-
-		#mkdir MICROSOFT
-		#cd MICROSOFT
-		#touch 
-		#cd .. 
-
-		mkdir OTHER
-		cd OTHER
-		touch desktop.desktop svg.svg text.txt
-			echo "GENERATING DESKTOP FILE"
-			echo '[Desktop Entry]' 					>> desktop.desktop
-			echo 'Version=1.0' 					>> desktop.desktop
-			echo 'Type=Application' 				>> desktop.desktop
-			echo 'Name=labelyourapp' 				>> desktop.desktop
-			echo 'Comment=shortdescriptionhere' 			>> desktop.desktop
-			echo 'Exec=appnamehere' 				>> desktop.desktop
-			echo 'Icon=/path/to/file' 				>> desktop.desktop
-			echo 'Path=' 						>> desktop.desktop
-			echo 'Terminal=true/false' 				>> desktop.desktop
-			echo 'StartupNotify=true/false' 			>> desktop.desktop
-		cd ..
-
-	cd ..
-
-	mkdir SCRIPTING
-	cd SCRIPTING
-
-		mkdir L
-		cd L
-		touch lua.lua
-			echo "GENERATING LUA TEMPLATE"
-			echo 'print("Hello, World!")' 				>> lua.lua
-		cd ..
-
-		mkdir P
-		cd P
-		touch python.py
-			echo "GENERATING PYTHON TEMPLATE"
-			echo '#!/usr/bin/env python' 				>> python.py
-			echo 'print "Hello, World"' 				>> python.py
-		cd ..
-
-		mkdir SHELL
-		cd SHELL
-		touch ba.sh da.sh fi.sh ion.sh nu.sh shell.sh z.sh 
-			echo '#!/bin/bash' 					>> bash.sh
-			echo 'echo "Hello, World!"' 				>> bash.sh
-
-			echo '#!/bin/dash'					>> dash.sh
-			echo 'echo "Hello, World!"'				>> dash.sh
-
-			echo '#!/bin/fish'					>> fi.sh
-			echo 'echo "Hello, World!"'				>> fi.sh
-
-			echo '#!/bin/ion' >> 					ion.sh
-			echo 'echo "Hello, World!' >> 				ion.sh
-
-			echo '#!/bin/nu' 					>> nu.sh
-			echo 'echo "Hello, World!"' 				>> nu.sh
-
-			echo '#!/bin/shell' 					>> shell.sh
-			echo 'echo "Hello, World!"' 				>> shell.sh
-
-			echo '#!/bin/zsh' 					>> z.sh
-			echo 'echo "Hello, World!"' 				>> z.sh
-		cd ..
-	cd ..
-
-	# WEB
-
-	mkdir WEB
-	cd WEB
-
-		touch css.css html.htm html.html javascript.js php.php sql.sql svg.svg webassemply.wasm
-			echo "GENERATING EMPTY CSS FILE"
-			echo '.class {' 					>> css.css
-			echo '' 						>> css.css
-			echo '}' 						>> css.css
-			echo ''							>> css.css
-			echo '#id {' 						>> css.css
-			echo '' 						>> css.css
-			echo '}' 						>> css.css
-
-			echo "GENERATING HTML TEMPLATE"
-			echo '<html>'						>> html.html
-			echo '<head>'						>> html.html
-			echo '</head>'						>> html.html
-			echo '<body>'						>> html.html
-			echo '<script src="Documents/web/html">' 		>> html.html
-			echo '</script>'					>> html.html
-			echo '<p>' 						>> html.html
-			echo '</p>' 						>> html.html
-			echo '</body>'						>> html.html
-			echo '</html>'						>> html.html
-
-			echo "GENERATING JAVASCRIPT TEMPLATE"
-			echo 'alert( "Hello, world! I am a separate file." );' 	>> javascript.js
-
-			echo "GENERATING PHP TEMPLATE"
-			echo '<?php' 						>> php.php
-			echo '	print("Hello, World!")' 			>> php.php
-			echo '?>' 						>> php.php
-
-			echo "GENERATING SVG TEMPLATE"
-			echo "<svg>" 						>> svg.svg
-			echo "</svg>" 						>> svg.svg
-	cd ..
-cd ..
+printf "GENERATING PHP TEMPLATE\n"
+printf "<?php\n\
+	  print(\"Hello, World!\")\n\
+	?>" > Templates/WEB/php.php
 
 # VIDEOS
+mkdir -p Videos/{mp4,ogv,webm}
 
-mkdir Videos
-cd Videos
-	mkdir mp4 ogv webm
-cd ..
-
-echo "GENERATION COMPLETE"
+printf "GENERATION COMPLETE\n"


### PR DESCRIPTION
What I did:
- All `echo`s changed to `printf` (`printf` is guaranteed to be a builtin unlike `echo`)
- Use single `printf` statements to redirect into the files
- Make all directories/subdirectories simultaneously per category
- Removed all the unhandled and unnecessary `cd`s
- Add a missing shebang at the beginning of the script
- Test if the top directories exist, and if not, create the directories